### PR TITLE
Link functions

### DIFF
--- a/doc/source/changelog.txt
+++ b/doc/source/changelog.txt
@@ -2,12 +2,13 @@
 Changelog
 =========
 
-Version 3.1 (2019/06/05)
+Version 3.1 (2019/11/15)
 ========================
 
 * workflows can get an "env" variable, like jobs do, and will apply their environment to all jobs
 * workflows can get an "env_builder_code" variable, which contains python source code which will be executed to build additional environment variables on the engine side when the workflow is submitted. This allows to handle client/server configurations, and partially some dynamic workflow tuning.
 * jobs env has been fixed in the local scheduler: it used to completely replace the env variables, now it just adds the new ones to the standard user variables.
+* Dynamic parameters in workflows: jobs can now have "named parameters" and outputs produced by a job (number, string, filename) are passed to downstream jobs. While passing values from a job output to another job input, custom link functions can be called to transform values, enabling applications such as map/reduce, cross-validation or leave-one-out in a semi-dynamic way.
 * some bug fixes especially in the PBSpro scheduler using python3
 
 

--- a/doc/source/changes_swf3.txt
+++ b/doc/source/changes_swf3.txt
@@ -19,7 +19,7 @@ Jobs may have "named parameters": a dictionary of parameters, which will be used
 
 Jobs may have "output parameters": also a dictionary of parameters, which may be written during a job execution as a JSON file, and which can be linked to input parameters of downstream jobs.
 
-Thus workflows may contain some "parameters links" to specify this.
+Thus workflows may contain some "parameters links" to specify this. Links can transform values to implement map/reduce or cross-validation pattens.
 
 See the details in the :ref:`dynamic_outputs` section.
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -270,6 +270,7 @@ epub_copyright = u'2019, '
 # Allow duplicate toc entries.
 #epub_tocdup = True
 
+autoclass_content = "both"
 
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {'http://docs.python.org/': None}

--- a/doc/source/workflow_creation.txt
+++ b/doc/source/workflow_creation.txt
@@ -248,6 +248,8 @@ Here ``job3`` must be modified to make it able to read the parameters file. In t
     print(open(in_file).read())
 
 
+.. _params_link_functions:
+
 Parameters link functions
 -------------------------
 
@@ -392,3 +394,11 @@ A map / reduce example::
                         root_group=[job1, group_1, reduce_job],
                         dependencies,
                         name='map-reduce', param_links=links)
+
+
+param_link_functions module
++++++++++++++++++++++++++++
+
+.. automodule:: param_link_functions
+    :members:
+

--- a/doc/source/workflow_creation.txt
+++ b/doc/source/workflow_creation.txt
@@ -77,6 +77,10 @@ Such a job will be "marked" as producing outputs (Job variable ``has_outputs``, 
 
 Then when running later jobs, their input values will be changed accordingly. To allow this, we need a few things:
 
+
+Using dynamic output parameters
+-------------------------------
+
 * such jobs should declare a dictionary of input parameters (Job variable ``param_dict``)
 
 * the workflow should define some "parameters links" between jobs in order to connect output parameters values from one job to the input parameters values of downstream jobs: Workflow variable ``param_linnks``.
@@ -99,7 +103,7 @@ To put things togethr in an example::
         name='job2:cat',
         param_dict={'in1': 'undefined'})
     workflow = Workflow(jobs=[job1, job2], name='test_workflow',
-                        param_links={job2: {'in1': (job1, 'out1')}})
+                        param_links={job2: {'in1': [(job1, 'out1')]}})
 
     # running it is the classical way
     # (or using soma_workflow_gui)
@@ -114,12 +118,12 @@ Here, ``job1`` will run a program, ``my_program`` which will do its job, and wri
 
     param_links = {
         dest_job1: {
-            'dest_param1': (src_job1, 'src_output_param1'),
-            'dest_param2': (src_job2, 'src_output_param2'),
+            'dest_param1': [(src_job1, 'src_output_param1')],
+            'dest_param2': [(src_job2, 'src_output_param2')],
         },
         dest_job2: {
-            'dest_param3': (src_job3, 'src_output_param3'),
-            'dest_param4': (src_job4, 'src_output_param4'),
+            'dest_param3': [(src_job3, 'src_output_param3')],
+            'dest_param4': [(src_job4, 'src_output_param4')],
         },
     }
 
@@ -157,7 +161,7 @@ As you can see, in a "classical" workflow, ``job2`` would not have known which f
 
 
 Dynamic outputs and file transfers
-==================================
+----------------------------------
 
 When a file name is an output of a job (the job decides where to write its output file), and this output file should be transfered from the computing resource to the client machine, then a FileTransfer object should be created (as usual), but with some little additional things to setup:
 
@@ -187,13 +191,13 @@ Ex::
         param_dict={'in1': toutp},
         referenced_input_files=ref_outp)
     workflow = swc.Workflow(jobs=[job1, job2], name='test_out_wf',
-                            param_links={job2: {'in1': (job1, 'out1')}})
+                            param_links={job2: {'in1': [(job1, 'out1')]}})
 
 
 .. _input_params_file:
 
 Job input parameters as file
-============================
+----------------------------
 
 When job parameters are specified through a dictionary of named parameters, it is also possible to pass the parameters set as a JSON file, rather than on commandline arguments. This may prove useful when the parameters list is long.
 
@@ -218,7 +222,7 @@ Ex::
         param_dict={'in1': 'undefined'},
         use_input_params_file=True)  # tell SWF to write the params file
     workflow2 = Workflow(jobs=[job1, job3], name='test_workflow',
-                         param_links={job3: {'in1': (job1, 'out1')}})
+                         param_links={job3: {'in1': [(job1, 'out1')]}})
 
     # running it is the classical way
     # (or using soma_workflow_gui)
@@ -243,3 +247,148 @@ Here ``job3`` must be modified to make it able to read the parameters file. In t
     # now the "real" job code just prints the file:
     print(open(in_file).read())
 
+
+Parameters link functions
+-------------------------
+
+To implement some classical schemas such as map/reduce or cross-validation patterns, we need to transform parameters values which are lists into a series of single values, each passed to a job, for instance. To do this, Soma-Workflow allows to specify link functions in ``param_links``. Such functions are called when building a job inputs before it runs (on engine side). Such functions are passed as an additional item in the link tuple, and may be strings (function definition, including module if appropriate), or a tuple containing a string (function definition) and arguments passed to it:
+
+Ex::
+
+    param_links = {
+        dest_job1: {
+            'dest_param1': [(src_job1, 'src_output_param1',
+                            'link_module.link_function')],
+            'dest_param2': [(src_job2, 'src_output_param2',
+                            ('link_module.link_function', 3))],
+        },
+    }
+
+Arguments, if used, are passed in the function as first parameters, and may be used to specify a counter or identifier for the linked job. Functions are then called using 4 additional arguments: source parameter name, source parameter value, destination parameter name, destination parameter current value. The function should return the new destination parameter value. The destination parameter current value is useful in some cases, for instance to build a list from several source links (reduce pattern).
+
+A few functions are directly available in Soma-Workflow, in the module :mod:`param_link_functions`, to help implementing classical algorithmic patterns:
+:func:`~param_link_functions.list_to_sequence`, :func:`~param_link_functions.sequence_to_list`, :func:`~param_link_functions.list_all_but_one`, :func:`~param_link_functions.list_cv_train_fold`, :func:`~param_link_functions.list_cv_test_fold`.
+
+Custom functions may be used, as long as their module is specified, with the additional constraint that the custom functions modules should be installed on engine side on the computing resource.
+
+Note that this parameters links transformations are the reason why links are lists and not single values: intuitively one may think that a job parameter value is linked from a single job output value, but when dealing with lists, the situatioon may differ: a list can be built from several outputs.
+
+A cross-validation pattern example::
+
+    # let's say job1 inputs a list and outputs another list, 'outputs'
+    job1 = Job(
+        command=['my_program', '%(inputs)s'], name='prepare_inputs',
+        param_dict={'inputs': ['file1', 'file2', 'file3', 'file4', 'file5']},
+        has_outputs=True)
+    # train_jobs are identical train jobs training folds (we use 3 folds)
+    # they output a single file, 'output'
+    # test_jobs are identical test jobs testing the test part of each fold
+    # they also output a single file, 'output'
+    nfolds = 3
+    train_jobs = []
+    test_jobs = []
+    for fold in range(nfolds):
+        job_train = Job(
+            command=['train_model', '%(inputs)s'], name='train_fold%d' % fold,
+            param_dict={'inputs', []}, has_outputs=True)
+        train_jobs.append(job_train)
+        job_test = Job(
+            command=['test_model', '%(inputs)s'], name='test_fold%d' % fold,
+            param_dict={'inputs', []}, has_outputs=True)
+        test_jobs.append(job_test)
+    # building the workflow
+    jobs = [job1] + train_jobs + test_jobs
+
+    dependencies = []
+    links = {}
+    for fold in range(nfolds):
+        links[train_jobs[fold]] = {
+            'inputs': [(job1, 'outputs',
+                       ('list_cv_train_fold', fold, nfolds))]}
+        links[test_jobs[fold]] = {
+            'inputs': [(job1, 'outputs',
+                       ('list_cv_test_fold', fold, nfolds))]}
+
+    workflow = Workflow(jobs,
+                        dependencies,
+                        name='train CV', param_links=links)
+
+A leave-one-out pattern example::
+
+    # let's say job1 inputs a list and outputs another list, 'outputs'
+    job1 = Job(
+        command=['my_program', '%(inputs)s'], name='prepare_inputs',
+        param_dict={'inputs': ['file1', 'file2', 'file3', 'file4', 'file5']},
+        has_outputs=True)
+    # train_jobs are identical train jobs training folds
+    # they output a single file, 'output'
+    # test_jobs are identical test jobs testing the single leftover file of
+    # each fold. They also output a single file, 'output'
+    nfolds = len(job1.param_dict['inputs'])
+    train_jobs = []
+    test_jobs = []
+    for fold in range(nfolds):
+        job_train = Job(
+            command=['train_model', '%(inputs)s'], name='train_fold%d' % fold,
+            param_dict={'inputs', []}, has_outputs=True)
+        train_jobs.append(job_train)
+        job_test = Job(
+            command=['test_model', '%(input)s'], name='test_fold%d' % fold,
+            param_dict={'input', 'undefined'}, has_outputs=True)
+        test_jobs.append(job_test)
+    # building the workflow
+    jobs = [job1] + train_jobs + test_jobs
+
+    dependencies = []
+    links = {}
+    for fold in range(nfolds):
+        links[train_jobs[fold]] = {
+            'inputs': [(job1, 'outputs',
+                       ('list_all_but_one', fold))]}
+        links[test_jobs[fold]] = {
+            'inputs': [(job1, 'outputs',
+                       ('list_to_sequence', fold))]}
+
+    workflow = Workflow(jobs,
+                        dependencies,
+                        name='train LOO', param_links=links)
+
+A map / reduce example::
+
+    # let's say job1 inputs a list and outputs another list, 'outputs'
+    job1 = Job(
+        command=['my_program', '%(inputs)s'], name='prepare_inputs',
+        param_dict={'inputs': ['file1', 'file2', 'file3', 'file4', 'file5']},
+        has_outputs=True)
+    # process_jobs are identical train jobs processing one of the input files
+    # they output a single file, 'output'
+    nfolds = len(job1.param_dict['inputs'])
+    process_jobs = []
+    for fold in range(nfolds):
+        job_proc = Job(
+            command=['process_data', '%(input)s'], name='process_%d' % fold,
+            param_dict={'input', 'undefined'}, has_outputs=True)
+        process_jobs.append(job_proc)
+    # a reduce node takes outputs of all processing nodes and, for instance,
+    # concatenates them
+    reduce_job = Job(
+        command=['cat_program', '%(inputs)s'], name='cat_results',
+        param_dict={'inputs': [], 'outputs': 'file_output'})
+
+    # building the workflow
+    group_1 = Group(name='processing', elements=process_jobs)
+    jobs = [job1] + process_jobs + [reduce_job]
+    dependencies = []
+    links = {}
+    links[reduce_job] = {'inputs': []}
+    for fold in range(nfolds):
+        links[process_jobs[fold]] = {
+            'inputs': [(job1, 'outputs',
+                       ('list_to_sequence', fold))]}
+        links[reduce_job]['inputs'].append((process_job[fold], 'output',
+                                            ('sequence_to_list', fold)))
+
+    workflow = Workflow(jobs,
+                        root_group=[job1, group_1, reduce_job],
+                        dependencies,
+                        name='map-reduce', param_links=links)

--- a/python/soma_workflow/client_types.py
+++ b/python/soma_workflow/client_types.py
@@ -820,7 +820,7 @@ class Workflow(object):
         New in 3.1.
         Job parameters links. Links are in the following shape:!
 
-            dest_job: {dest_param: (source_job, param, [function])}
+            dest_job: {dest_param: [(source_job, param, <function>), ...]}
 
         Links are used to get output values from jobs which have completed
         their run, and to set them into downstream jobs inputs. This system
@@ -889,7 +889,7 @@ class Workflow(object):
 
         param_links is an (optional) dict which specifies these links::
 
-            {dest_job: {dest_param: (source_job, param, [function])}}
+            {dest_job: {dest_param: [(source_job, param, <function>), ...]}}
 
         Such links de facto define new jobs dependencies, which are added to
         the dependencies manually specified.
@@ -1004,8 +1004,9 @@ class Workflow(object):
         else:
             current_deps = set(self.dependencies)
         for dest_job, links in six.iteritems(self.param_links):
-            for p, link in six.iteritems(links):
-                deps.add((link[0], dest_job))
+            for p, linkl in six.iteritems(links):
+                for link in linkl:
+                    deps.add((link[0], dest_job))
         if isinstance(self.dependencies, list):
             for dep in deps:
                 if dep not in current_deps:
@@ -1077,8 +1078,9 @@ class Workflow(object):
         for dest_job, links in six.iteritems(self.param_links):
             wdjob = job_ids[dest_job]
             wlinks = {}
-            for dest_par, link in six.iteritems(links):
-                wlinks[dest_par] = (job_ids[link[0]], ) + link[1:]
+            for dest_par, linkl in six.iteritems(links):
+                for link in linkl:
+                    wlinks[dest_par] = (job_ids[link[0]], ) + link[1:]
             new_links[wdjob] = wlinks
         wf_dict['param_links'] = new_links
 
@@ -1252,9 +1254,12 @@ class Workflow(object):
         for dest_job, links in six.iteritems(id_links):
             ddest_job = job_from_ids[int(dest_job)]
             dlinks = {}
-            for lname, link in six.iteritems(links):
-                dsrc_job = job_from_ids[link[0]]
-                dlinks[lname] = (dsrc_job, ) + link[1:]
+            for lname, linkl in six.iteritems(links):
+                dlinkl = []
+                for link in linkl:
+                    dsrc_job = job_from_ids[link[0]]
+                    dlinkl.append((dsrc_job, ) + link[1:])
+                dlinks[lname] = dlinkl
             param_links[ddest_job] = dlinks
 
         # user storage, TODO: handle objects in it

--- a/python/soma_workflow/client_types.py
+++ b/python/soma_workflow/client_types.py
@@ -121,16 +121,19 @@ class Job(object):
         specification will be ignored (documentation configuration item: NATIVE_SPECIFICATION).
 
         *Example:* Specification of a job walltime and more:
-          * using a PBS cluster: native_specification="-l walltime=10:00:00,pmem=16gb"
-          * using a SGE cluster: native_specification="-l h_rt=10:00:00"
+
+        * using a PBS cluster: native_specification="-l walltime=10:00:00,pmem=16gb"
+        * using a SGE cluster: native_specification="-l h_rt=10:00:00"
 
     parallel_job_info: dict
         The parallel job information must be set if the Job is parallel (ie. made to
         run on several CPU).
         The parallel job information is a dict, with the following supported items:
-            * config_name: name of the configuration (native, MPI, OpenMP)
-            * nodes_number: number of computing nodes used by the Job,
-            * cpu_per_node: number of CPU or cores needed for each node
+
+        * config_name: name of the configuration (native, MPI, OpenMP)
+        * nodes_number: number of computing nodes used by the Job,
+        * cpu_per_node: number of CPU or cores needed for each node
+
         The configuration name is the type of parallel Job. Example: MPI or OpenMP.
 
         .. warning::
@@ -176,9 +179,8 @@ class Job(object):
         Path to the file which will be written for output parameters of the
         job.
 
-    ..
-      **disposal_timeout**: int
-      Only requiered outside of a workflow
+    disposal_timeout: int
+        Only requiered outside of a workflow
     '''
 
     # sequence of sequence of string or/and FileTransfer or/and
@@ -772,7 +774,6 @@ class Workflow(object):
 
     Attributes
     ----------
-
     name: string
         Name of the workflow which will be displayed in the GUI.
         Default: workflow_id once submitted
@@ -818,7 +819,7 @@ class Workflow(object):
 
     param_links: dict
         New in 3.1.
-        Job parameters links. Links are in the following shape:!
+        Job parameters links. Links are in the following shape::
 
             dest_job: {dest_param: [(source_job, param, <function>), ...]}
 
@@ -834,6 +835,8 @@ class Workflow(object):
         parameter name, destination parameter current value. The destination
         parameter value is typically used to build / update a list in the
         destination job from a series of values in source jobs.
+
+        See :ref:`params_link_functions` for details.
 
     '''
     # string
@@ -903,6 +906,18 @@ class Workflow(object):
         parameter name, destination parameter current value. The destination
         parameter value is typically used to build / update a list in the
         destination job from a series of values in source jobs.
+
+        Parameters
+        ----------
+        jobs
+        dependencies
+        root_group
+        disposal_timeout
+        user_storage
+        name
+        env
+        env_builder_code
+        param_links
 
         '''
         import logging

--- a/python/soma_workflow/database_server.py
+++ b/python/soma_workflow/database_server.py
@@ -1820,7 +1820,7 @@ class WorkflowDatabaseServer(object):
                             esrc_job = engine_workflow.job_mapping[link[0]]
                             func = None
                             if len(link) > 2:
-                                func = pickle.dumps(link[2])
+                                func = sqlite3.Binary(pickle.dumps(link[2]))
                             cursor.execute(
                                 '''INSERT INTO param_links
                                 (workflow_id,

--- a/python/soma_workflow/engine.py
+++ b/python/soma_workflow/engine.py
@@ -578,9 +578,12 @@ class WorkflowEngineLoop(object):
         u_param_dict = self._database_server.updated_job_parameters(job.job_id)
         if u_param_dict:
             for param, value_tl in six.iteritems(u_param_dict):
+                dval = job.param_dict.get(param)
+                if isinstance(dval, list):
+                    # reset list parameters
+                    dval = []
                 for value_t in value_tl:
                     func, src_param, value = value_t
-                    dval = job.param_dict.get(param)
                     value = transformed_param_value(func, src_param, value,
                                                     param, dval)
                     if isinstance(dval, SpecialPath):
@@ -1269,9 +1272,12 @@ class WorkflowEngine(RemoteFileController):
         if u_param_dict:
             param_dict = {}
             for param, value_tl in six.iteritems(u_param_dict):
+                dval = job.param_dict.get(param)
+                if isinstance(dval, list):
+                    # reset lists
+                    dval = []
                 for value_t in value_tl:
                     func, src_param, value = value_t
-                    dval = job.param_dict.get(param)
                     value = transformed_param_value(func, src_param, value,
                                                     param, dval)
                     param_dict[param] = value

--- a/python/soma_workflow/gui/workflowGui.py
+++ b/python/soma_workflow/gui/workflowGui.py
@@ -3111,17 +3111,22 @@ class JobInfoWidget(QtGui.QTabWidget):
                     if workflow:
                         links = workflow.param_links.get(job_item.data)
                         if links:
-                            link = links.get(param_name)
-                            if link:
-                                item = QtGui.QTableWidgetItem(
-                                    '%s.%s' % (link[0].name, link[1]))
-                                if engine_wf:
-                                    item.job_id \
-                                        = job_mapping.get(
-                                            link[0], link[0]).job_id
-                                else:
-                                    item.job_id \
-                                        = job_mapping.get(link[0])
+                            linkl = links.get(param_name, [])
+                            if linkl:
+                                linkstr = []
+                                job_ids = []
+                                for link in linkl:
+                                    linkstr.append(
+                                        '%s.%s' % (link[0].name, link[1]))
+                                    if engine_wf:
+                                        job_ids.append(job_mapping.get(
+                                            link[0], link[0]).job_id)
+                                    else:
+                                        job_ids.append(job_mapping.get(
+                                            link[0]))
+                                linkstr = ', '.join(linkstr)
+                                item = QtGui.QTableWidgetItem(linkstr)
+                                item.job_ids = job_ids
                                 table.setItem(i, 2, item)
                 table.cellDoubleClicked.connect(
                     self.input_param_double_clicked)
@@ -3249,9 +3254,9 @@ class JobInfoWidget(QtGui.QTabWidget):
     def input_param_double_clicked(self, row, col):
         if col == 2:
             item = self.ui.input_params_contents.item(row, col)
-            job_id = getattr(item, 'job_id', None)
-            if job_id is not None:
-                self.source_job_selected.emit(job_id)
+            job_ids = getattr(item, 'job_ids', None)
+            if job_ids:
+                self.source_job_selected.emit(job_ids[0])
 
 
 class TransferInfoWidget(QtGui.QTabWidget):

--- a/python/soma_workflow/param_link_functions.py
+++ b/python/soma_workflow/param_link_functions.py
@@ -20,3 +20,48 @@ def sequence_to_list(item, src_param, value, dst_param, dst_value):
     dst_value[item] = value
     return dst_value
 
+
+def list_all_but_one(item, src_param, value, dst_param, dst_value):
+    ''' remove item-th element from the input list.
+    Useful in a leave-one-out pattern
+    '''
+    return value[:item] + value[item+1:]
+
+
+def list_cv_train_fold(fold, nfolds, src_param, value, dst_param, dst_value):
+    ''' take all but fold-th division in a list divided into nfold folds.
+    Useful in a nfolds cross-validation pattern
+    '''
+    nitems = len(value)
+    fold_size = nitems // nfolds
+    nsupp = nitems % nfolds
+    begin = fold_size * fold
+    begin += min(begin, nsupp)
+    end = fold_size * (fold + 1)
+    end += min(end, nsupp)
+    return value[:begin] + value[end:]
+
+
+def list_cv_test_fold(fold, nfolds, src_param, value, dst_param, dst_value):
+    ''' take fold-th division in a list divided into nfold folds.
+    Useful in a nfolds cross-validation pattern
+    '''
+    nitems = len(value)
+    fold_size = nitems // nfolds
+    nsupp = nitems % nfolds
+    begin = fold_size * fold
+    begin += min(begin, nsupp)
+    end = fold_size * (fold + 1)
+    end += min(end, nsupp)
+    return value[begin:end]
+
+
+# this one cannot work by now because links order is not known.
+#def list_cat(item, src_param, value, dst_param, dst_value):
+    #''' concatenates lists: extend value (list) after dst_value
+    #'''
+    #if dst_value is None:
+        #dst_value = []
+    #dst_value += value
+    #return dst_value
+

--- a/python/soma_workflow/param_link_functions.py
+++ b/python/soma_workflow/param_link_functions.py
@@ -15,13 +15,22 @@ def list_to_sequence(item, src_param, value, dst_param, dst_value):
 
 
 def sequence_to_list(item, src_param, value, dst_param, dst_value):
-    ''' set the value value as item-th element of list dest_value
+    ''' set the value value as item-th element of list dst_value
     '''
     if dst_value is None:
         dst_value = [Undefined] * (item + 1)
     if len(dst_value) <= item:
         dst_value += [Undefined] * (item + 1 - len(dst_value))
     dst_value[item] = value
+    return dst_value
+
+
+def append_to_list(src_param, value, dst_param, dst_value):
+    ''' appends the value value at the end of list dst_value
+    '''
+    if dst_value is None:
+        dst_value = []
+    dst_value.append(value)
     return dst_value
 
 
@@ -60,12 +69,11 @@ def list_cv_test_fold(fold, nfolds, src_param, value, dst_param, dst_value):
     return value[begin:end]
 
 
-# this one cannot work by now because links order is not known.
-#def list_cat(item, src_param, value, dst_param, dst_value):
-    #''' concatenates lists: extend value (list) after dst_value
-    #'''
-    #if dst_value is None:
-        #dst_value = []
-    #dst_value += value
-    #return dst_value
+def list_cat(item, src_param, value, dst_param, dst_value):
+    ''' concatenates lists: extend value (list) after dst_value
+    '''
+    if dst_value is None:
+        dst_value = []
+    dst_value += value
+    return dst_value
 

--- a/python/soma_workflow/param_link_functions.py
+++ b/python/soma_workflow/param_link_functions.py
@@ -1,0 +1,22 @@
+
+from __future__ import print_function
+
+from traits.api import Undefined
+
+
+def list_to_sequence(item, src_param, value, dst_param, dst_value):
+    ''' item-th element of list value
+    '''
+    return value[item]
+
+
+def sequence_to_list(item, src_param, value, dst_param, dst_value):
+    ''' set the value value as item-th element of list dest_value
+    '''
+    if dst_value is None:
+        dst_value = [Undefined] * (item + 1)
+    if len(dst_value) <= item:
+        dst_value += [Undefined] * (item + 1 - len(dst_value))
+    dst_value[item] = value
+    return dst_value
+

--- a/python/soma_workflow/param_link_functions.py
+++ b/python/soma_workflow/param_link_functions.py
@@ -1,7 +1,11 @@
 
 from __future__ import print_function
 
-from traits.api import Undefined
+try:
+    from traits.api import Undefined
+except ImportError:
+    # no traits: use None
+    Undefined = None
 
 
 def list_to_sequence(item, src_param, value, dst_param, dst_value):

--- a/python/soma_workflow/test/data/jobExamples/complete/file1
+++ b/python/soma_workflow/test/data/jobExamples/complete/file1
@@ -1,0 +1,4 @@
+
+
+This is a Soma-Workflow example file used as input to job and workflow tests.
+

--- a/python/soma_workflow/test/data/jobExamples/complete/file5
+++ b/python/soma_workflow/test/data/jobExamples/complete/file5
@@ -1,0 +1,1 @@
+another test file.

--- a/python/soma_workflow/test/data/jobExamples/complete/job7.py
+++ b/python/soma_workflow/test/data/jobExamples/complete/job7.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python
+
+# inputs: as env var SOMAWF_INPUT_PARAMS
+# expect "inputs" parameter: list of filenames
+# outputs: copies of files in intermediate_results/ subdirectory
+
+from __future__ import print_function
+
+import os
+import json
+import sys
+import shutil
+
+input_param_file = os.environ.get('SOMAWF_INPUT_PARAMS')
+input_dict = json.load(open(input_param_file))
+input_params = input_dict['parameters']
+
+filePathsIn = input_params['inputs']
+out_dir = input_params['output_dir']
+
+if not os.path.exists(out_dir):
+    os.mkdir(out_dir)
+
+filePathsOut = [os.path.join(out_dir, os.path.basename(f))
+                for f in filePathsIn]
+
+for fin, fout in zip(filePathsIn, filePathsOut):
+    shutil.copy2(fin, fout)
+
+# write output parameters
+output_param_file = os.environ.get('SOMAWF_OUTPUT_PARAMS')
+
+if output_param_file:
+    out_params = {
+        'outputs': filePathsOut,
+    }
+    json.dump(out_params, open(output_param_file, 'w'))
+

--- a/python/soma_workflow/test/data/jobExamples/complete/job8.py
+++ b/python/soma_workflow/test/data/jobExamples/complete/job8.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python
+
+# input: "input" param in json dict
+# output: filename is an output of this job
+
+from __future__ import print_function
+
+import os
+import sys
+import json
+import shutil
+
+# get the input pams file location from env variable
+param_file = os.environ.get('SOMAWF_INPUT_PARAMS')
+# read it
+param_json = json.load(open(param_file))
+parameters = param_json['parameters']
+# now get our specific parameter(s)
+filePathIn = parameters['input']
+timeToSleep = parameters.get('timeToSleep')
+
+in_dir = os.path.dirname(filePathIn)
+out_dir = os.path.join(in_dir, 'job8_output')
+try:
+    os.mkdir(out_dir)
+except:
+    pass  # already exists because of previous run or concurrent run
+
+filePathOut = os.path.join(out_dir, 'job8_%s' % os.path.basename(filePathIn))
+
+with open(filePathIn) as fin:
+    with open(filePathOut, 'w') as fout:
+        print('job8 output:', file=fout)
+        print('------------', file=fout)
+        fout.write(fin.read())
+
+# write output parameters
+output_param_file = os.environ.get('SOMAWF_OUTPUT_PARAMS')
+
+if output_param_file:
+    out_params = {
+        'output': filePathOut,
+    }
+    json.dump(out_params, open(output_param_file, 'w'))
+

--- a/python/soma_workflow/test/data/jobExamples/complete/job8.py
+++ b/python/soma_workflow/test/data/jobExamples/complete/job8.py
@@ -17,7 +17,6 @@ param_json = json.load(open(param_file))
 parameters = param_json['parameters']
 # now get our specific parameter(s)
 filePathIn = parameters['input']
-timeToSleep = parameters.get('timeToSleep')
 
 in_dir = os.path.dirname(filePathIn)
 out_dir = os.path.join(in_dir, 'job8_output')

--- a/python/soma_workflow/test/data/jobExamples/complete/job9.py
+++ b/python/soma_workflow/test/data/jobExamples/complete/job9.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python
+
+# input: "inputs" param in json dict, list of files
+# output: "output" filename is an intput of this job
+
+from __future__ import print_function
+
+import os
+import sys
+import json
+import shutil
+
+# get the input pams file location from env variable
+param_file = os.environ.get('SOMAWF_INPUT_PARAMS')
+# read it
+param_json = json.load(open(param_file))
+parameters = param_json['parameters']
+# now get our specific parameter(s)
+filePathsIn = parameters['inputs']
+filePathOut = parameters['output']
+
+with open(filePathOut, 'w') as fout:
+    for filein in filePathsIn:
+        with open(filein) as fin:
+            fout.write(fin.read())
+

--- a/python/soma_workflow/test/data/jobExamples/complete/output_models/file13
+++ b/python/soma_workflow/test/data/jobExamples/complete/output_models/file13
@@ -1,0 +1,24 @@
+job8 output:
+------------
+
+Ingredients
+
+    * 1 1/2 cups all-purpose flour
+    * 3 1/2 teaspoons baking powder
+    * 1 teaspoon salt
+    * 1 tablespoon white sugar
+    * 1 1/4 cups milk
+    * 1 egg
+    * 3 tablespoons butter, melted
+
+Directions
+
+   1. In a large bowl, sift together the flour, baking powder, salt and sugar. Make a well in the center and pour in the milk, egg and melted butter; mix until smooth.
+   2. Heat a lightly oiled griddle or frying pan over medium high heat. Pour or scoop the batter onto the griddle, using approximately 1/4 cup for each pancake. Brown on both sides and serve hot.
+
+job8 output:
+------------
+
+
+This is a Soma-Workflow example file used as input to job and workflow tests.
+

--- a/python/soma_workflow/test/data/jobExamples/complete/output_models/file14
+++ b/python/soma_workflow/test/data/jobExamples/complete/output_models/file14
@@ -1,0 +1,41 @@
+
+Ingredients
+
+    * 1 1/2 cups all-purpose flour
+    * 3 1/2 teaspoons baking powder
+    * 1 teaspoon salt
+    * 1 tablespoon white sugar
+    * 1 1/4 cups milk
+    * 1 egg
+    * 3 tablespoons butter, melted
+
+Directions
+
+   1. In a large bowl, sift together the flour, baking powder, salt and sugar. Make a well in the center and pour in the milk, egg and melted butter; mix until smooth.
+   2. Heat a lightly oiled griddle or frying pan over medium high heat. Pour or scoop the batter onto the griddle, using approximately 1/4 cup for each pancake. Brown on both sides and serve hot.
+
+
+
+This is a Soma-Workflow example file used as input to job and workflow tests.
+
+
+Ingredients
+
+    * 1 1/2 cups all-purpose flour
+    * 3 1/2 teaspoons baking powder
+    * 1 teaspoon salt
+    * 1 tablespoon white sugar
+    * 1 1/4 cups milk
+    * 1 egg
+    * 3 tablespoons butter, melted
+
+Directions
+
+   1. In a large bowl, sift together the flour, baking powder, salt and sugar. Make a well in the center and pour in the milk, egg and melted butter; mix until smooth.
+   2. Heat a lightly oiled griddle or frying pan over medium high heat. Pour or scoop the batter onto the griddle, using approximately 1/4 cup for each pancake. Brown on both sides and serve hot.
+
+
+
+This is a Soma-Workflow example file used as input to job and workflow tests.
+
+another test file.

--- a/python/soma_workflow/test/data/jobExamples/complete/output_models/file15
+++ b/python/soma_workflow/test/data/jobExamples/complete/output_models/file15
@@ -1,0 +1,3 @@
+job8 output:
+------------
+another test file.

--- a/python/soma_workflow/test/data/jobExamples/complete/output_models/file16
+++ b/python/soma_workflow/test/data/jobExamples/complete/output_models/file16
@@ -1,0 +1,25 @@
+
+Ingredients
+
+    * 1 1/2 cups all-purpose flour
+    * 3 1/2 teaspoons baking powder
+    * 1 teaspoon salt
+    * 1 tablespoon white sugar
+    * 1 1/4 cups milk
+    * 1 egg
+    * 3 tablespoons butter, melted
+
+Directions
+
+   1. In a large bowl, sift together the flour, baking powder, salt and sugar. Make a well in the center and pour in the milk, egg and melted butter; mix until smooth.
+   2. Heat a lightly oiled griddle or frying pan over medium high heat. Pour or scoop the batter onto the griddle, using approximately 1/4 cup for each pancake. Brown on both sides and serve hot.
+
+
+
+This is a Soma-Workflow example file used as input to job and workflow tests.
+
+
+
+This is a Soma-Workflow example file used as input to job and workflow tests.
+
+another test file.

--- a/python/soma_workflow/test/data/jobExamples/complete/output_models/file17
+++ b/python/soma_workflow/test/data/jobExamples/complete/output_models/file17
@@ -1,0 +1,17 @@
+another test file.
+
+Ingredients
+
+    * 1 1/2 cups all-purpose flour
+    * 3 1/2 teaspoons baking powder
+    * 1 teaspoon salt
+    * 1 tablespoon white sugar
+    * 1 1/4 cups milk
+    * 1 egg
+    * 3 tablespoons butter, melted
+
+Directions
+
+   1. In a large bowl, sift together the flour, baking powder, salt and sugar. Make a well in the center and pour in the milk, egg and melted butter; mix until smooth.
+   2. Heat a lightly oiled griddle or frying pan over medium high heat. Pour or scoop the batter onto the griddle, using approximately 1/4 cup for each pancake. Brown on both sides and serve hot.
+

--- a/python/soma_workflow/test/workflow_tests/test_simple.py
+++ b/python/soma_workflow/test/workflow_tests/test_simple.py
@@ -185,6 +185,16 @@ class SimpleTest(WorkflowTest):
         workflow = self.wf_examples.example_dynamic_outputs_with_mapreduce()
         return self.run_workflow(workflow, test_files=[13])
 
+    def test_workflow_loo(self):
+        workflow = self.wf_examples.example_dynamic_outputs_with_loo()
+        return self.run_workflow(
+            workflow, test_files=[14],
+            test_dyn_files={'test': {'output': 15}})
+
+    def test_workflow_cv(self):
+        workflow = self.wf_examples.example_dynamic_outputs_with_cv()
+        return self.run_workflow(workflow, test_files=[16, 17])
+
 
 def test():
     return SimpleTest.run_test_function(**WorkflowTest.parse_args(sys.argv))

--- a/python/soma_workflow/test/workflow_tests/workflow_examples/workflow_examples.py
+++ b/python/soma_workflow/test/workflow_tests/workflow_examples/workflow_examples.py
@@ -446,6 +446,58 @@ class WorkflowExamples(object):
                             name=function_name, param_links=links)
         return workflow
 
+    def example_dynamic_outputs_with_loo(self):
+        # small leave-one-out
+        # jobs
+        job1 = self.job_list_with_outputs2()
+        job2_train = self.job_reduce_cat(14)
+        job2_train.name = 'train'
+        job2_test = self.job8_with_output()
+        job2_test.name = 'test'
+        # building the workflow
+        jobs = [job1, job2_train, job2_test]
+
+        dependencies = []
+
+        links = {
+            job2_train: {'inputs': [(job1, 'outputs',
+                                     ('list_all_but_one', 2))]},
+            job2_test: {'input': [(job1, 'outputs', ('list_to_sequence', 2))]},
+        }
+
+        function_name = inspect.stack()[0][3]
+        workflow = Workflow(jobs,
+                            dependencies,
+                            root_group=[job1, job2_train, job2_test],
+                            name=function_name, param_links=links)
+        return workflow
+
+    def example_dynamic_outputs_with_cv(self):
+        # small 4-fold cross-validation
+        # jobs
+        job1 = self.job_list_with_outputs2()
+        job2_train = self.job_reduce_cat(16)
+        job2_train.name = 'train'
+        job2_test = self.job_reduce_cat(17)
+        job2_test.name = 'test'
+        # building the workflow
+        jobs = [job1, job2_train, job2_test]
+
+        dependencies = []
+
+        links = {
+            job2_train: {'inputs': [(job1, 'outputs',
+                                     ('list_cv_train_fold', 1, 4))]},
+            job2_test: {'inputs': [(job1, 'outputs',
+                                    ('list_cv_test_fold', 1, 4))]},
+        }
+
+        function_name = inspect.stack()[0][3]
+        workflow = Workflow(jobs,
+                            dependencies,
+                            root_group=[job1, job2_train, job2_test],
+                            name=function_name, param_links=links)
+        return workflow
 
 if __name__ == "__main__":
     print(WorkflowExamples.get_workflow_example_list())

--- a/python/soma_workflow/test/workflow_tests/workflow_examples/workflow_local.py
+++ b/python/soma_workflow/test/workflow_tests/workflow_examples/workflow_local.py
@@ -39,6 +39,7 @@ class WorkflowExamplesLocal(WorkflowExamples):
         # Complete path
         self.complete_path = os.path.join(self.examples_dir, "complete")
         self.lo_file[0] = os.path.join(self.complete_path, "file0")
+        self.lo_file[1] = os.path.join(self.complete_path, "file1")
         self.lo_exceptionJobScript = os.path.join(self.complete_path,
                                                   "exception_job.py")
         self.lo_sleep_script = os.path.join(self.complete_path,
@@ -53,7 +54,7 @@ class WorkflowExamplesLocal(WorkflowExamples):
         self.lo_stdout_command_local = os.path.join(
             self.models_path, "stdout_local_special_command")
 
-        for i in range(1, 7):
+        for i in range(1, 10):
             self.lo_script[i] = os.path.join(self.complete_path,
                                              "job" + str(i) + ".py")
             self.lo_stdin[i] = os.path.join(self.complete_path,
@@ -61,7 +62,7 @@ class WorkflowExamplesLocal(WorkflowExamples):
             self.lo_stdout[i] = os.path.join(self.models_path,
                                              "stdout_job" + str(i))
 
-        for i in [11, 12, 2, 3, 4]:
+        for i in [11, 12, 2, 3, 4, 13]:
             self.lo_file[i] = os.path.join(self.output_dir, "file" + str(i))
             self.lo_out_model_file[i] = os.path.join(self.models_path,
                                                      "file" + str(i))
@@ -193,3 +194,41 @@ class WorkflowExamplesLocal(WorkflowExamples):
                    has_outputs=True,
                    use_input_params_file=True)
         return job2
+
+    def job8_with_output(self):
+        time_to_wait = 1
+        job_name = 'job8_with_output'
+        job = Job([sys.executable, '%(script)s'],
+                  None, None,
+                  self.lo_stdin[2], False, 168, job_name,
+                  param_dict={'script': self.lo_script[8],
+                              'input': 'nothing',
+                              'timeToSleep': str(time_to_wait)},
+                   has_outputs=True,
+                   use_input_params_file=True)
+        return job
+
+    def job_list_with_outputs(self):
+        job_name = 'copy_files'
+        job = Job([sys.executable, '%(script)s'],
+                  None, None,
+                  self.lo_stdin[2], False, 168, job_name,
+                  param_dict={'script': self.lo_script[7],
+                              'inputs': [self.lo_file[0], self.lo_file[1]],
+                              'output_dir': os.path.join(
+                                  self.output_dir, 'intermediate_results')},
+                  has_outputs=True,
+                  use_input_params_file=True)
+        return job
+
+    def job_reduce_cat(self):
+        job_name = 'cat_files'
+        job = Job([sys.executable, '%(script)s'],
+                  None, None,
+                  self.lo_stdin[2], False, 168, job_name,
+                  param_dict={'script': self.lo_script[9],
+                              'inputs': [],
+                              'output': self.lo_file[13]},
+                  use_input_params_file=True)
+        return job
+

--- a/python/soma_workflow/test/workflow_tests/workflow_examples/workflow_local.py
+++ b/python/soma_workflow/test/workflow_tests/workflow_examples/workflow_local.py
@@ -38,8 +38,8 @@ class WorkflowExamplesLocal(WorkflowExamples):
 
         # Complete path
         self.complete_path = os.path.join(self.examples_dir, "complete")
-        self.lo_file[0] = os.path.join(self.complete_path, "file0")
-        self.lo_file[1] = os.path.join(self.complete_path, "file1")
+        for i in [0, 1, 5]:
+            self.lo_file[i] = os.path.join(self.complete_path, "file%d" % i)
         self.lo_exceptionJobScript = os.path.join(self.complete_path,
                                                   "exception_job.py")
         self.lo_sleep_script = os.path.join(self.complete_path,
@@ -62,7 +62,7 @@ class WorkflowExamplesLocal(WorkflowExamples):
             self.lo_stdout[i] = os.path.join(self.models_path,
                                              "stdout_job" + str(i))
 
-        for i in [11, 12, 2, 3, 4, 13]:
+        for i in [11, 12, 2, 3, 4, 13, 14, 15, 16, 17]:
             self.lo_file[i] = os.path.join(self.output_dir, "file" + str(i))
             self.lo_out_model_file[i] = os.path.join(self.models_path,
                                                      "file" + str(i))
@@ -202,10 +202,9 @@ class WorkflowExamplesLocal(WorkflowExamples):
                   None, None,
                   self.lo_stdin[2], False, 168, job_name,
                   param_dict={'script': self.lo_script[8],
-                              'input': 'nothing',
-                              'timeToSleep': str(time_to_wait)},
-                   has_outputs=True,
-                   use_input_params_file=True)
+                              'input': 'nothing'},
+                  has_outputs=True,
+                  use_input_params_file=True)
         return job
 
     def job_list_with_outputs(self):
@@ -221,14 +220,29 @@ class WorkflowExamplesLocal(WorkflowExamples):
                   use_input_params_file=True)
         return job
 
-    def job_reduce_cat(self):
+    def job_list_with_outputs2(self):
+        job_name = 'copy_files2'
+        job = Job([sys.executable, '%(script)s'],
+                  None, None,
+                  self.lo_stdin[2], False, 168, job_name,
+                  param_dict={'script': self.lo_script[7],
+                              'inputs': [self.lo_file[0], self.lo_file[1],
+                                         self.lo_file[5], self.lo_file[0],
+                                         self.lo_file[1], self.lo_file[5]],
+                              'output_dir': os.path.join(
+                                  self.output_dir, 'intermediate_results')},
+                  has_outputs=True,
+                  use_input_params_file=True)
+        return job
+
+    def job_reduce_cat(self, file_num=13):
         job_name = 'cat_files'
         job = Job([sys.executable, '%(script)s'],
                   None, None,
                   self.lo_stdin[2], False, 168, job_name,
                   param_dict={'script': self.lo_script[9],
                               'inputs': [],
-                              'output': self.lo_file[13]},
+                              'output': self.lo_file[file_num]},
                   use_input_params_file=True)
         return job
 


### PR DESCRIPTION
Allows to call link functions when assigning output values as new job inputs. Enables cross-validation, leave-one-out or map.reduce patterns, and more.
The database format has changed again.
Fixes: #43