### PR TITLE
Miscellaneous code clean-ups

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ before_install:
     - if [[ "$TRAVIS_OS_NAME" = "linux" && "$TRAVIS_PYTHON_VERSION" == "3.5" ]]; then sudo apt-get install -y pandoc graphviz; pip install sphinx sphinx-gallery pandoc nbsphinx "PyQt5<5.13"; fi
 
 install:
-    - pip install six
+    - pip install 'six~=1.12'
     - if [ ${TRAVIS_PYTHON_VERSION} == "2.7" ]; then pip install subprocess32; fi
     - pip install codecov
     - python setup.py install

--- a/python/soma_workflow/client.py
+++ b/python/soma_workflow/client.py
@@ -31,8 +31,7 @@ import logging
 import six
 import tempfile
 
-if sys.version_info[:2] >= (2, 6):
-    import json
+import json
 # import cProfile
 # import traceback
 
@@ -1173,14 +1172,8 @@ def _embedded_engine_and_server(config):
         if not os.path.exists(os.path.dirname(server_log_file)):
             os.makedirs(os.path.dirname(server_log_file))
 
-    if sys.version_info >= (2, 7):
-        import logging.config
-        logging.config.dictConfig(log_config)
-    elif engine_log_dir:
-        logging.basicConfig(
-            filename=logfilepath,
-            format=engine_log_format,
-            level=eval("logging." + engine_log_level))
+    import logging.config
+    logging.config.dictConfig(log_config)
 
     if engine_log_dir:
         logger = logging.getLogger('engine')
@@ -1452,9 +1445,6 @@ class Helper(object):
         file usable in Python 2.5.
         '''
         from soma_workflow import utils
-
-        if sys.version_info[:2] < (2, 6):
-            raise Exception("convert_wf_file_for_p2_5 requires Python >= 2.6.")
 
         try:
             o_file = open(origin_file_path, "r")

--- a/python/soma_workflow/connection.py
+++ b/python/soma_workflow/connection.py
@@ -32,6 +32,8 @@ import sys
 import io
 import traceback
 from . import subprocess
+
+import six
 import six.moves.socketserver as socketserver
 
 from soma_workflow.errors import ConnectionError
@@ -157,7 +159,7 @@ def SSH_exec_cmd(sshcommand,
 def server_python_interpreter():
     ''' python command to run on server side '''
     python_interpreter = os.path.basename(sys.executable)
-    if sys.version_info[0] >= 3 and python_interpreter == 'python':
+    if not six.PY2 and python_interpreter == 'python':
         # force the use of python3 if we use it on client side
         python_interpreter = 'python%d' % sys.version_info[0]
     return python_interpreter

--- a/python/soma_workflow/engine_types.py
+++ b/python/soma_workflow/engine_types.py
@@ -23,6 +23,7 @@ uses on the client side (in the GUI for example) without importing
 module required in the engine module.
 '''
 
+import io
 import os
 import logging
 import tempfile
@@ -374,14 +375,12 @@ class EngineJob(Job):
                 new_command = (
                     command.pattern
                     % self.path_mapping[command].get_engine_path())
-                if sys.version_info[0] < 3:
-                    new_command = new_command.encode('utf-8')
+                new_command = six.ensure_str(new_command, 'utf-8')
             else:
                 new_command = (
                     command.pattern
                     % self.path_mapping[command].get_engine_main_path())
-                if sys.version_info[0] < 3:
-                    new_command = new_command.encode('utf-8')
+                new_command = six.ensure_str(new_command, 'utf-8')
         else:
             # If the entry is anything else, we return its string
             # representation
@@ -658,13 +657,9 @@ class EngineWorkflow(Workflow):
             t = tempfile.mkstemp(prefix='swf_', suffix='.py')
             try:
                 os.close(t[0])
-                if sys.version_info[0] >= 3:
-                    f = open(t[1], 'w', encoding='utf-8')
-                else:
-                    f = open(t[1], 'w')
-                f.write(self.env_builder_code)
-                f.write('\n')
-                f.close()
+                with io.open(t[1], 'w', encoding='utf-8') as f:
+                    f.write(six.ensure_text(self.env_builder_code))
+                    f.write(u'\n')
                 try:
                     env_json = subprocess.check_output([sys.executable,
                                                         t[1]]).decode('utf-8')

--- a/python/soma_workflow/gui/workflowGui.py
+++ b/python/soma_workflow/gui/workflowGui.py
@@ -7,7 +7,6 @@
 from __future__ import with_statement, print_function
 from __future__ import absolute_import
 
-from six.moves import range
 import time
 import threading
 import os
@@ -114,30 +113,11 @@ from soma_workflow.test.workflow_tests import WorkflowExamplesTransfer
 from soma_workflow.errors import UnknownObjectError, ConfigurationError, SerializationError, WorkflowError, JobError, ConnectionError
 import soma_workflow.version as version
 
-# python 2/3 compatibility
 import six
-import sys
+from six.moves import range
 
-if sys.version_info[0] >= 3:
-    def utf8(string):
-        return six.text_type(string)
-else:
-    def utf8(string):
-        try:
-            return six.text_type(string).encode('utf-8')
-        except UnicodeDecodeError as e:
-            s1 = [string[:e.start - 1] + '?']
-            s2 = string[e.end:]
-            while s2:
-                try:
-                    x = six.text_type(s2)
-                    s1.append(x)
-                    s2 = ''
-                except UnicodeDecodeError as e:
-                    s1.append(s2[:e.start - 1] + '?')
-                    s2 = s2[e.end:]
-            return ''.join(s1).encode('utf-8')
-
+def utf8(string):
+    return six.ensure_str(six.ensure_text(string, errors='replace'), 'utf-8')
 
 
 MATPLOTLIB = True
@@ -1161,8 +1141,7 @@ class ConnectionDialog(QtGui.QDialog):
     def update_login(self):
         resource_id = six.text_type(
             self.ui.combo_resources.currentText())
-        if sys.version_info[0] < 3:
-            resource_id = resource_id.encode('utf-8')
+        resource_id = six.ensure_str(resource_id, 'utf-8')
         login = self.login_list[resource_id]
         if login != None:
             self.ui.lineEdit_login.setText(login)

--- a/python/soma_workflow/gui/workflowGui.py
+++ b/python/soma_workflow/gui/workflowGui.py
@@ -147,21 +147,14 @@ except ImportError as e:
     print("Could not use Matplotlib: %s %s" % (type(e), e))
     MATPLOTLIB = False
 
-try:
-    if sys.version_info[0] >= 3:
-        from Pyro4.errors import ConnectionClosedError
-    else:
-        from Pyro.errors import ConnectionClosedError
-except ImportError:
-    # Pyro is not required when soma-workflow runs as a one process application
-    class PyroError(Exception):
-        pass
 
-    class ProtocolError(PyroError):
-        pass
+class ProtocolError(Exception):
+    pass
 
-    class ConnectionClosedError(ProtocolError):
-        pass
+
+class ConnectionClosedError(ProtocolError):
+    pass
+
 
 # QFileDialog options:
 # in binary packages containing thirdpary libs/python, we must use 

--- a/python/soma_workflow/info.py
+++ b/python/soma_workflow/info.py
@@ -54,7 +54,7 @@ AUTHOR_EMAIL = "support@brainvisa.info"
 PLATFORMS = "OS Independent"
 PROVIDES = ["soma-workflow"]
 REQUIRES = [
-    "six>=1.12",
+    "six~=1.12",
     "argparse",
 ]
 EXTRA_REQUIRES = {

--- a/python/soma_workflow/test/workflow_tests/workflow_test.py
+++ b/python/soma_workflow/test/workflow_tests/workflow_test.py
@@ -25,10 +25,8 @@ from soma_workflow.test.workflow_tests import WorkflowExamplesLocal
 from soma_workflow.test.workflow_tests import WorkflowExamplesShared
 from soma_workflow.test.workflow_tests import WorkflowExamplesSharedTransfer
 from soma_workflow.test.workflow_tests import WorkflowExamplesTransfer
-if sys.version_info[0] >= 3:
-    import io as StringIO
-else:
-    import StringIO
+
+from six.moves import StringIO
 
 
 class WorkflowTest(unittest.TestCase):
@@ -75,7 +73,7 @@ class WorkflowTest(unittest.TestCase):
         swf_conf = '[%s]\nSOMA_WORKFLOW_DIR = %s\n' \
             % (socket.gethostname(), tmpdb)
         Configuration.search_config_path \
-            = staticmethod(lambda: StringIO.StringIO(swf_conf))
+            = staticmethod(lambda: StringIO(swf_conf))
 
         self.temporaries = [self.wf_examples.output_dir]
 

--- a/python/somadrmaa/helpers.py
+++ b/python/somadrmaa/helpers.py
@@ -27,8 +27,9 @@ import ctypes as _ct
 from somadrmaa.wrappers import *
 from somadrmaa.errors import error_buffer
 import somadrmaa.const as const
-import six
 import sys
+
+import six
 
 _BUFLEN = const.ATTR_BUFFER
 
@@ -37,7 +38,7 @@ try:
 except ImportError:  # pre 2.6 behaviour
     from somadrmaa import nt as _nt
 
-if sys.version_info[0] < 3:
+if six.PY2:
     def c_str(s):
         return s
 else:
@@ -138,7 +139,7 @@ Attribute constructor.
    implementation. See BoolConverter for an example.
 """
         self.name = c_str(name)
-        if type_converter is None and sys.version_info[0] >= 3:
+        if type_converter is None and not six.PY2:
             type_converter = StringConverter
         self.converter = type_converter
 


### PR DESCRIPTION
Some of the new code requires `six >= 1.12`, but an older version is installed with some Python versions on Travis (Python 2.7 and 3.7).

We could add `six >= 1.12` to the Travis configuration, but shouldn't `soma-workflow` be free of external dependencies, so that it works out of the box when installed on a server with the auto-install feature? On the other hand, the auto-install feature seems to be broken anyway (https://github.com/populse/soma-workflow/issues/56).

I see two ways forward:

1. Really require `six >= 1.12`, add it to the Travis config, and find a way to make the auto-install functional or deprecate it entirely;

2. Get rid of the dependency of `six` by incorporating `six.py` in the code. This is allowed by the licence, and actually [we did it already for casa-distro](https://github.com/brainvisa/casa-distro/blob/master/python/casa_distro/six.py).

@populse/soma what is your preference betwee solution 1 / solution 2?