### PR TITLE
Setting the line's pick radius via set_picker is deprecated.

### DIFF
--- a/python/soma_workflow/gui/workflowGui.py
+++ b/python/soma_workflow/gui/workflowGui.py
@@ -3571,7 +3571,7 @@ class PlotView(QtGui.QWidget):
         # tolerence seems to work only on line artists anyway.
         for p in self.axes.lines + self.axes.patches:
             if p is not None:
-                p.set_picker(tolerance)
+                p.set_pickradius(tolerance)
 
         self.canvas.draw()
 


### PR DESCRIPTION
[Since matplotlib3.3 and will be removed two minor releases later](https://matplotlib.org/3.3.4/api/_as_gen/matplotlib.axes.Axes.set_picker.html).
